### PR TITLE
feat: toast 컴포넌트 레이어 및 유연성 개선

### DIFF
--- a/src/components/common/Toast/Toast.tsx
+++ b/src/components/common/Toast/Toast.tsx
@@ -4,36 +4,33 @@ import AlertIcon from "@/assets/alert-white.svg";
 /**
  * Coworkers 프로젝트의 공통 알림(Toast) 컴포넌트입니다.
  * * @description
- * - 화면 하단에 고정되어 사용자에게 변경사항 알림 및 저장 액션을 제공합니다.
- * - Desktop(max-w: 868px)과 Mobile(w: 100% - 32px)에 최적화된 반응형 UI를 지원합니다.
- * - 웹/태블릿 환경에서는 아이콘이 노출되며, 모바일 환경(sm 미만)에서는 텍스트 공간 확보를 위해 아이콘이 숨겨집니다.
- * * @component
- * @param {Object} props - Toast 컴포넌트의 Props
- * @param {string} props.message - 토스트에 표시될 메시지 (예: "저장하지 않은 변경사항이 있어요!")
- * @param {() => void} props.onSave - '변경사항 저장하기' 버튼 클릭 시 실행될 핸들러 함수
- * @param {() => void} props.onClose - 토스트가 닫힐 때(자동 소멸 포함) 부모 상태를 제어하기 위한 콜백 함수
- * @param {number} [props.duration=5000] - 토스트가 화면에 유지되는 시간 (ms 단위, 기본값 5초)
- * * @example
- * <Toast
- * message="저장하지 않은 변경사항이 있어요!"
- * onSave={handleSave}
- * onClose={() => setShowToast(false)}
- * />
+ * - 화면 하단에 고정되어 사용자에게 알림 또는 액션 버튼을 제공합니다.
+ * - z-index를 99로 설정하여 다른 UI 요소보다 상단에 노출되도록 개선되었습니다.
+ * - 버튼(action)은 선택 사항이며, 없을 경우 일반 안내형 토스트로 동작합니다.
+ * * @param {Object} props
+ * @param {string} props.message - 토스트에 표시될 메시지
+ * @param {string} [props.actionLabel] - 버튼에 표시될 텍스트 (기본값: "확인")
+ * @param {() => void} [props.onAction] - 버튼 클릭 시 실행될 핸들러 (없으면 버튼이 렌더링되지 않음)
+ * @param {() => void} props.onClose - 토스트가 닫힐 때 실행되는 콜백
+ * @param {number} [props.duration=5000] - 유지 시간 (ms)
  */
-
 interface ToastProps {
   message: string;
-  onSave: () => void;
+  actionLabel?: string; // 버튼 텍스트를 유동적으로 변경
+  onAction?: () => void; // 필수(onSave)에서 선택(onAction)으로 변경
   onClose: () => void;
   duration?: number;
 }
 
-const Toast = ({ message, onSave, onClose, duration = 5000 }: ToastProps) => {
+const Toast = ({
+  message,
+  actionLabel = "확인",
+  onAction,
+  onClose,
+  duration = 5000,
+}: ToastProps) => {
   const [isExiting, setIsExiting] = useState<boolean>(false);
 
-  /**
-   * 토스트를 닫기 전 애니메이션을 실행하고 onClose 콜백을 호출합니다.
-   */
   const handleClose = useCallback(() => {
     setIsExiting(true);
     setTimeout(onClose, 300);
@@ -49,7 +46,7 @@ const Toast = ({ message, onSave, onClose, duration = 5000 }: ToastProps) => {
 
   return (
     <div
-      className={`bg-brand-primary fixed bottom-8 left-1/2 z-50 flex -translate-x-1/2 items-center justify-between shadow-lg transition-all duration-300 ease-in-out ${
+      className={`bg-brand-primary fixed bottom-8 left-1/2 z-1000 flex -translate-x-1/2 items-center justify-between shadow-lg transition-all duration-300 ease-in-out ${
         isExiting ? "translate-y-2 opacity-0" : "translate-y-0 opacity-100"
       } w-[calc(100vw-32px)] max-w-217 rounded-2xl px-3 py-3 sm:w-full sm:px-6 sm:py-4`}
     >
@@ -57,17 +54,22 @@ const Toast = ({ message, onSave, onClose, duration = 5000 }: ToastProps) => {
         <div className="hidden shrink-0 sm:block">
           <AlertIcon width="24" height="24" className="text-color-inverse" />
         </div>
-        <span className="text-color-inverse sm:text-lg-sb text-sm whitespace-nowrap">
+        <span className="text-color-inverse sm:text-lg-sb overflow-hidden text-sm text-ellipsis whitespace-nowrap">
           {message}
         </span>
       </div>
 
-      <button
-        onClick={onSave}
-        className="hover:bg-opacity-90 bg-background-inverse text-md-sb text-brand-primary ml-2 h-9 w-auto min-w-25 shrink-0 rounded-lg px-2 text-center transition-colors sm:h-10 sm:min-w-31.25 sm:px-4"
-      >
-        변경사항 저장하기
-      </button>
+      {onAction && (
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onAction();
+          }}
+          className="hover:bg-opacity-90 bg-background-inverse text-md-sb text-brand-primary ml-4 h-9 w-auto min-w-20 shrink-0 rounded-lg px-3 text-center transition-colors sm:h-10 sm:min-w-25 sm:px-4"
+        >
+          {actionLabel}
+        </button>
+      )}
     </div>
   );
 };

--- a/src/pages/test/TestToast.tsx
+++ b/src/pages/test/TestToast.tsx
@@ -1,57 +1,74 @@
 import React, { useState } from "react";
-import Toast from "@/components/common/Toast/toast";
+import Toast from "@/components/common/Toast/Toast";
 
 const ToastTestPage = () => {
-  const [showToast, setShowToast] = useState<boolean>(false);
-
-  const handleOpenToast = () => {
-    setShowToast(true);
-  };
-
-  const handleSave = () => {
-    alert("변경사항이 성공적으로 저장되었습니다!");
-    setShowToast(false);
-  };
+  // 토스트 종류 상태: none(없음), info(안내), save(저장)
+  const [activeToast, setActiveToast] = useState<"none" | "info" | "save">(
+    "none",
+  );
 
   const handleClose = () => {
-    setShowToast(false);
+    setActiveToast("none");
+  };
+
+  const handleSaveAction = () => {
+    alert("변경사항이 성공적으로 저장되었습니다!");
+    handleClose();
   };
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center bg-gray-50 p-6">
+    <div className="font-pretendard flex min-h-screen flex-col items-center justify-center bg-gray-50 p-6">
       <div className="w-full max-w-md rounded-xl bg-white p-8 text-center shadow-md">
-        <h1 className="mb-4 text-2xl font-bold text-gray-800">
+        <h1 className="text-2xl-b text-color-primary mb-4">
           Toast Component Test
         </h1>
-        <p className="mb-8 text-gray-600">
-          아래 버튼을 누르면 'Coworkers' 프로젝트용 공통 토스트가 나타납니다.
-          <br />
+        <p className="text-md-r text-color-tertiary mb-8">
+          수정된 유동적인 토스트 옵션을 테스트해보세요.
         </p>
 
-        <button
-          onClick={handleOpenToast}
-          className="w-full rounded-lg bg-[#718AFF] px-6 py-3 font-bold text-white shadow-lg transition-colors hover:bg-[#5a74e6] active:scale-95"
-        >
-          토스트 띄우기
-        </button>
-      </div>
+        <div className="flex flex-col gap-3">
+          {/* 1. 일반 안내형 (버튼 없이 메시지만 노출) */}
+          <button
+            onClick={() => setActiveToast("info")}
+            className="bg-color-tertiary text-md-sb w-full rounded-lg px-6 py-3 text-white shadow-md transition-all hover:opacity-90 active:scale-95"
+          >
+            일반 안내형 토스트
+          </button>
 
-      {/* 가이드 문구 */}
-      <div className="mt-10 text-center text-sm text-gray-400">
-        <p>💡 개발자 도구(F12)를 켜서 모바일 뷰로 전환해보세요!</p>
-        <p>화면 너비에 따라 토스트 크기가 유동적으로 변합니다.</p>
-      </div>
-
-      {/* 토스트 컨테이너: 하단 중앙 고정 */}
-      {showToast && (
-        <div className="fixed bottom-10 left-1/2 z-9999 flex w-full -translate-x-1/2 justify-center px-5">
-          <Toast
-            message="저장하지 않은 변경사항이 있어요!"
-            onSave={handleSave}
-            onClose={handleClose}
-            duration={5000}
-          />
+          {/* 2. 저장 액션형 (기존 요구사항 반영) */}
+          <button
+            onClick={() => setActiveToast("save")}
+            className="bg-brand-primary text-md-sb hover:bg-interaction-hover w-full rounded-lg px-6 py-3 text-white shadow-md transition-all active:scale-95"
+          >
+            저장 액션 토스트
+          </button>
         </div>
+      </div>
+
+      <div className="text-sm-r text-color-disabled mt-10 text-center">
+        <p>💡 버튼(onAction) 유무에 따라 토스트 UI가 유동적으로 변합니다.</p>
+        <p>현재 z-index는 [99]로 설정되어 있습니다.</p>
+      </div>
+
+      {/* --- 토스트 렌더링 영역 --- */}
+
+      {/* 안내형: onAction을 넘기지 않아 버튼이 렌더링되지 않음 */}
+      {activeToast === "info" && (
+        <Toast
+          message="알림 메시지가 도착했습니다."
+          onClose={handleClose}
+          duration={3000}
+        />
+      )}
+
+      {/* 저장형: actionLabel과 onAction을 넘겨 버튼 활성화 */}
+      {activeToast === "save" && (
+        <Toast
+          message="저장하지 않은 변경사항이 있어요!"
+          actionLabel="변경사항 저장하기"
+          onAction={handleSaveAction}
+          onClose={handleClose}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #4 

## 📝작업 내용
- [x] z-index를 1000로 조정하여 UI 레이어 겹침 해결
- [x] onAction 프롭을 선택사항으로 변경하여 일반 안내형/액션형 통합 지원
- [x] 버튼 라벨(actionLabel) 커스텀 기능 추가
- [x] 테스트 페이지 내 다양한 토스트 케이스(안내/저장) 검증 코드 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
