### PR TITLE
fix: useSuspenseQuery 사용 컴포넌트에 FetchBoundary 추가 및 Skeleton UX 개선

### DIFF
--- a/src/components/gnb/desktop/DesktopGnb.tsx
+++ b/src/components/gnb/desktop/DesktopGnb.tsx
@@ -5,6 +5,7 @@ import UnFoldIcon from "@/assets/fold-false.svg";
 import GnbUserProfile from "../shared/GnbUserProfile";
 import { useGnbStore } from "../useGnbStore";
 import { useAuthStore } from "@/stores/useAuthStore";
+import { FetchBoundary } from "@/providers/boundary";
 import UserProfile from "@/assets/user.svg";
 import { Link } from "react-router-dom";
 
@@ -81,7 +82,19 @@ export default function DesktopGnb() {
         }`}
       >
         <div className="mt-[20px]">
-          <GnbUserProfile />
+          <FetchBoundary
+            loadingFallback={
+              <div className="flex items-center gap-3 px-1">
+                <div className="bg-background-tertiary h-10 w-10 animate-pulse rounded-[12px]" />
+                <div className="flex-1 space-y-1">
+                  <div className="bg-background-tertiary h-4 w-20 animate-pulse rounded" />
+                  <div className="bg-background-tertiary h-3 w-14 animate-pulse rounded" />
+                </div>
+              </div>
+            }
+          >
+            <GnbUserProfile />
+          </FetchBoundary>
         </div>
       </div>
 

--- a/src/components/gnb/desktop/DesktopHeaderMenus.tsx
+++ b/src/components/gnb/desktop/DesktopHeaderMenus.tsx
@@ -2,13 +2,24 @@ import DesktopTeamSelector from "./DesktopTeamSelector";
 import AddTeamButton from "../shared/AddTeamButton";
 import DesktopNavLinks from "./DesktopNavLinks";
 import { useGnbStore } from "../useGnbStore";
+import { FetchBoundary } from "@/providers/boundary";
 
 export default function DesktopHeaderMenus() {
   const isFolded = useGnbStore((state) => state.isFolded);
 
   return (
     <div>
-      <DesktopTeamSelector />
+      <FetchBoundary
+        loadingFallback={
+          <div className="space-y-2 px-4 pt-6">
+            <div className="bg-background-tertiary h-9 w-full animate-pulse rounded-lg" />
+            <div className="bg-background-tertiary h-8 w-full animate-pulse rounded-lg" />
+            <div className="bg-background-tertiary h-8 w-full animate-pulse rounded-lg" />
+          </div>
+        }
+      >
+        <DesktopTeamSelector />
+      </FetchBoundary>
       <div className={isFolded ? "hidden" : "mb-6 px-4"}>
         <AddTeamButton size="sm" />
       </div>

--- a/src/components/gnb/mobile/MobileGnb.tsx
+++ b/src/components/gnb/mobile/MobileGnb.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import MobileUserArea from "./MobileUserArea";
 import MobileHeaderMenus from "./MobileHeaderMenus";
 import { useAuthStore } from "@/stores/useAuthStore";
+import { FetchBoundary } from "@/providers/boundary";
 import { useLocation } from "react-router-dom";
 
 export default function MobileGnb() {
@@ -30,10 +31,12 @@ export default function MobileGnb() {
     <>
       <header className="border-border-primary relative w-full md:border-r md:border-solid">
         <MobileUserArea onMenuOpen={setIsMenuOpen} />
-        <MobileHeaderMenus
-          isOpen={isMenuOpen}
-          onClose={() => setIsMenuOpen(false)}
-        />
+        <FetchBoundary loadingFallback={null}>
+          <MobileHeaderMenus
+            isOpen={isMenuOpen}
+            onClose={() => setIsMenuOpen(false)}
+          />
+        </FetchBoundary>
       </header>
     </>
   );

--- a/src/features/TeamMemberSectiom/TeamMemberSkeleton.tsx
+++ b/src/features/TeamMemberSectiom/TeamMemberSkeleton.tsx
@@ -1,0 +1,28 @@
+/**
+ * TeamMemberSection 로딩 스켈레톤
+ * - 멤버 카드 레이아웃 (240px 카드 + 헤더 + 멤버 목록 플레이스홀더)
+ */
+export default function TeamMemberSkeleton() {
+  return (
+    <div className="bg-background-primary border-border-primary w-[240px] rounded-[12px] border-1 px-[20px] py-[24px]">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1">
+          <div className="bg-background-tertiary h-5 w-10 animate-pulse rounded" />
+          <div className="bg-background-tertiary h-5 w-12 animate-pulse rounded" />
+        </div>
+        <div className="bg-background-tertiary h-5 w-16 animate-pulse rounded" />
+      </div>
+
+      {/* 멤버 리스트 */}
+      <div className="mt-[24px] space-y-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="flex items-center gap-3">
+            <div className="bg-background-tertiary h-8 w-8 animate-pulse rounded-full" />
+            <div className="bg-background-tertiary h-4 w-28 animate-pulse rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/TodayProgressSection/TodayProgressSkeleton.tsx
+++ b/src/features/TodayProgressSection/TodayProgressSkeleton.tsx
@@ -1,0 +1,25 @@
+/**
+ * TodayProgressSection 로딩 스켈레톤
+ * - 그룹 헤더 + 진행도 통계 + 프로그레스 바 플레이스홀더
+ */
+export default function TodayProgressSkeleton() {
+  return (
+    <div className="bg-background-inverse rounded-[20px] p-6 shadow-[0_15px_50px_-12px_rgba(0,0,0,0.05)]">
+      {/* 그룹 헤더 */}
+      <div className="flex items-center justify-between">
+        <div className="bg-background-tertiary h-6 w-40 animate-pulse rounded" />
+        <div className="bg-background-tertiary h-8 w-20 animate-pulse rounded-lg" />
+      </div>
+
+      {/* 진행도 통계 */}
+      <div className="mt-4 flex gap-6">
+        <div className="bg-background-tertiary h-10 w-24 animate-pulse rounded" />
+        <div className="bg-background-tertiary h-10 w-24 animate-pulse rounded" />
+        <div className="bg-background-tertiary h-10 w-24 animate-pulse rounded" />
+      </div>
+
+      {/* 프로그레스 바 */}
+      <div className="bg-background-tertiary mt-4 h-2 w-full animate-pulse rounded-full" />
+    </div>
+  );
+}

--- a/src/features/taskcolumn/TaskColumnSkeleton.tsx
+++ b/src/features/taskcolumn/TaskColumnSkeleton.tsx
@@ -1,0 +1,37 @@
+/**
+ * TaskColumn 로딩 스켈레톤
+ * - 헤더 + 3개 컬럼(할 일 / 진행중 / 완료) 플레이스홀더
+ */
+export default function TaskColumnSkeleton() {
+  return (
+    <div>
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <div className="flex gap-1">
+          <div className="bg-background-tertiary h-5 w-20 animate-pulse rounded" />
+          <div className="bg-background-tertiary h-5 w-10 animate-pulse rounded" />
+        </div>
+        <div className="bg-background-tertiary h-8 w-24 animate-pulse rounded-lg" />
+      </div>
+
+      {/* 3개 컬럼 */}
+      <div className="mt-[16px] justify-between md:mt-[30px] md:flex md:gap-[16px]">
+        {["할 일", "진행중", "완료"].map((label) => (
+          <div key={label} className="mt-[16px] flex-1 first:mt-0 md:mt-0">
+            <div className="bg-background-tertiary flex items-center rounded-[12px] py-[10px] pl-[20px]">
+              <div className="bg-background-secondary h-4 w-12 animate-pulse rounded" />
+            </div>
+            <div className="mt-[20px] space-y-3">
+              {Array.from({ length: 2 }).map((_, i) => (
+                <div
+                  key={i}
+                  className="bg-background-primary h-[80px] animate-pulse rounded-[12px]"
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/AddTeam.tsx
+++ b/src/pages/AddTeam.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { FetchBoundary } from "@/providers/boundary";
 import { Button } from "@/components/common/Button/Button";
 import { Input } from "@/components/common/Input/Input";
 import { useCreateGroup } from "@/api/group";
@@ -7,7 +8,34 @@ import { useGroups } from "@/api/user";
 import { useToastStore } from "@/stores/useToastStore";
 import TeamImageUpload from "@/features/team/components/TeamImageUpload";
 
-export default function AddTeam() {
+/** 카드 폼 스켈레톤 (이미지 + 입력 + 버튼) */
+function AddTeamSkeleton() {
+  return (
+    <div>
+      <div className="flex h-[100vh] flex-col items-center justify-center">
+        <div className="bg-background-primary w-[calc(100%-20px)] max-w-[550px] rounded-[20px] px-[20px] pt-[52px] pb-[74px] md:px-[45px] md:pt-[61px] md:pb-[64px]">
+          <div className="bg-background-tertiary mb-[32px] h-8 w-32 animate-pulse rounded md:mb-[48px]" />
+          <div className="flex justify-center">
+            <div className="bg-background-tertiary h-[100px] w-[100px] animate-pulse rounded-full" />
+          </div>
+          <div className="mt-[12px] space-y-2 md:mt-[32px]">
+            <div className="bg-background-tertiary h-4 w-16 animate-pulse rounded" />
+            <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+          </div>
+          <div className="mt-[40px]">
+            <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+          </div>
+          <div className="mt-[20px] flex justify-center md:mt-[24px]">
+            <div className="bg-background-tertiary h-4 w-64 animate-pulse rounded" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 데이터 의존 콘텐츠 (useSuspenseQuery 사용) */
+function AddTeamContent() {
   // 데이터 불러오기
   const { data: groups } = useGroups();
 
@@ -18,7 +46,7 @@ export default function AddTeam() {
 
   // 훅 및 유틸리티
   const navigate = useNavigate();
-  const { mutate } = useCreateGroup();
+  const { mutate, isPending } = useCreateGroup();
   const toast = useToastStore();
 
   const TEAM_NAME_REGEX = /^[a-zA-Z0-9가-힣_]+$/;
@@ -42,7 +70,7 @@ export default function AddTeam() {
   const isValid = name !== "" && nameError === "";
 
   const handleSubmit = () => {
-    if (!isValid) return;
+    if (!isValid || isPending) return;
 
     mutate(
       { name, image: imageUrl },
@@ -90,10 +118,10 @@ export default function AddTeam() {
             <Button
               size="authWide"
               onClick={handleSubmit}
-              disabled={!isValid}
+              disabled={!isValid || isPending}
               className="disabled:cursor-not-allowed disabled:opacity-50"
             >
-              생성하기
+              {isPending ? "생성 중..." : "생성하기"}
             </Button>
           </div>
           <p className="text-color-default text-xs-r md:text-lg-r mt-[20px] text-center md:mt-[24px]">
@@ -102,5 +130,13 @@ export default function AddTeam() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function AddTeam() {
+  return (
+    <FetchBoundary loadingFallback={<AddTeamSkeleton />}>
+      <AddTeamContent />
+    </FetchBoundary>
   );
 }

--- a/src/pages/EditTeam.tsx
+++ b/src/pages/EditTeam.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { FetchBoundary } from "@/providers/boundary";
 import { Button } from "@/components/common/Button/Button";
 import { Input } from "@/components/common/Input/Input";
 import { useGroup, useUpdateGroup } from "@/api/group";
@@ -7,7 +8,34 @@ import { useGroups } from "@/api/user";
 import { useToastStore } from "@/stores/useToastStore";
 import TeamImageUpload from "@/features/team/components/TeamImageUpload";
 
-export default function EditTeam() {
+/** 카드 폼 스켈레톤 (이미지 + 입력 + 버튼) */
+function EditTeamSkeleton() {
+  return (
+    <div>
+      <div className="flex h-[100vh] flex-col items-center justify-center">
+        <div className="bg-background-primary w-[calc(100%-20px)] max-w-[550px] rounded-[20px] px-[20px] pt-[52px] pb-[74px] md:px-[45px] md:pt-[61px] md:pb-[64px]">
+          <div className="bg-background-tertiary mb-[32px] h-8 w-32 animate-pulse rounded md:mb-[48px]" />
+          <div className="flex justify-center">
+            <div className="bg-background-tertiary h-[100px] w-[100px] animate-pulse rounded-full" />
+          </div>
+          <div className="mt-[12px] space-y-2 md:mt-[32px]">
+            <div className="bg-background-tertiary h-4 w-16 animate-pulse rounded" />
+            <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+          </div>
+          <div className="mt-[40px]">
+            <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+          </div>
+          <div className="mt-[20px] flex justify-center md:mt-[24px]">
+            <div className="bg-background-tertiary h-4 w-64 animate-pulse rounded" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 데이터 의존 콘텐츠 (useSuspenseQuery 사용) */
+function EditTeamContent() {
   // 데이터 불러오기
   const { id: groupId } = useParams();
   const { data: group } = useGroup(Number(groupId));
@@ -20,7 +48,7 @@ export default function EditTeam() {
 
   // 훅 및 유틸
   const navigate = useNavigate();
-  const { mutate } = useUpdateGroup();
+  const { mutate, isPending } = useUpdateGroup();
   const toast = useToastStore();
 
   const TEAM_NAME_REGEX = /^[a-zA-Z0-9가-힣_]+$/;
@@ -44,7 +72,7 @@ export default function EditTeam() {
   const isValid = name !== "" && nameError === "";
 
   const handleSubmit = () => {
-    if (!isValid) return;
+    if (!isValid || isPending) return;
 
     mutate(
       { id: Number(groupId), data: { name, image: imageUrl } },
@@ -92,10 +120,10 @@ export default function EditTeam() {
             <Button
               size="authWide"
               onClick={handleSubmit}
-              disabled={!isValid}
+              disabled={!isValid || isPending}
               className="disabled:cursor-not-allowed disabled:opacity-50"
             >
-              수정하기
+              {isPending ? "수정 중..." : "수정하기"}
             </Button>
           </div>
           <p className="text-color-default text-xs-r md:text-lg-r mt-[20px] text-center md:mt-[24px]">
@@ -104,5 +132,13 @@ export default function EditTeam() {
         </div>
       </div>
     </div>
+  );
+}
+
+export default function EditTeam() {
+  return (
+    <FetchBoundary loadingFallback={<EditTeamSkeleton />}>
+      <EditTeamContent />
+    </FetchBoundary>
   );
 }

--- a/src/pages/JoinTeam.tsx
+++ b/src/pages/JoinTeam.tsx
@@ -1,3 +1,4 @@
+import { FetchBoundary } from "@/providers/boundary";
 import { useAcceptGroupInvitation } from "@/api/group";
 import { useUser } from "@/api/user";
 import { Button } from "@/components/common/Button/Button";
@@ -7,14 +8,36 @@ import { useToastStore } from "@/stores/useToastStore";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-export default function JoinTeam() {
+/** 카드 폼 스켈레톤 (입력 + 버튼) */
+function JoinTeamSkeleton() {
+  return (
+    <div className="flex h-[100vh] flex-col items-center justify-center">
+      <div className="bg-background-primary w-[calc(100%-20px)] max-w-[550px] rounded-[20px] px-[20px] pt-[52px] pb-[74px] md:px-[45px] md:pt-[61px] md:pb-[64px]">
+        <div className="bg-background-tertiary mb-[32px] h-8 w-32 animate-pulse rounded md:mb-[48px]" />
+        <div className="mt-[12px] space-y-2 md:mt-[32px]">
+          <div className="bg-background-tertiary h-4 w-16 animate-pulse rounded" />
+          <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+        </div>
+        <div className="mt-[40px]">
+          <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+        </div>
+        <div className="mt-[20px] flex justify-center md:mt-[24px]">
+          <div className="bg-background-tertiary h-4 w-64 animate-pulse rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/** 데이터 의존 콘텐츠 (useSuspenseQuery 사용) */
+function JoinTeamContent() {
   // 상태 관리
   const [teamLink, setTeamLink] = useState<string>("");
   const [teamLinkError, setTeamLinkError] = useState<string>("");
 
   // 훅
   const { data: user } = useUser();
-  const { mutate } = useAcceptGroupInvitation();
+  const { mutate, isPending } = useAcceptGroupInvitation();
   const navigate = useNavigate();
   const toast = useToastStore();
 
@@ -25,8 +48,8 @@ export default function JoinTeam() {
   };
 
   const handleSubmit = () => {
-    if (!teamLink) {
-      setTeamLinkError("팀 링크를 입력해주세요.");
+    if (!teamLink || isPending) {
+      if (!teamLink) setTeamLinkError("팀 링크를 입력해주세요.");
       return;
     }
 
@@ -80,10 +103,10 @@ export default function JoinTeam() {
             <Button
               size="authWide"
               onClick={handleSubmit}
-              disabled={!teamLink}
+              disabled={!teamLink || isPending}
               className="disabled:cursor-not-allowed disabled:opacity-50"
             >
-              참여하기
+              {isPending ? "참여 중..." : "참여하기"}
             </Button>
           </div>
           <p className="text-color-default text-xs-r md:text-lg-r mt-[20px] text-center md:mt-[24px]">
@@ -92,5 +115,13 @@ export default function JoinTeam() {
         </div>
       </div>
     </>
+  );
+}
+
+export default function JoinTeam() {
+  return (
+    <FetchBoundary loadingFallback={<JoinTeamSkeleton />}>
+      <JoinTeamContent />
+    </FetchBoundary>
   );
 }

--- a/src/pages/MySettings.tsx
+++ b/src/pages/MySettings.tsx
@@ -254,15 +254,49 @@ function MySettingsContent() {
   );
 }
 
+/** 계정 설정 페이지 로딩 스켈레톤 */
+function MySettingsSkeleton() {
+  return (
+    <div className="bg-background-secondary min-h-screen pb-24">
+      <div className="px-4 pt-6 md:px-[56px] md:pt-10 lg:ml-[184px] lg:pt-14">
+        <div className="bg-background-primary mx-auto w-full max-w-[940px] rounded-[20px] px-4 pt-10 pb-10 md:px-[45px] lg:w-[940px] lg:px-[74px]">
+          {/* 타이틀 */}
+          <div className="bg-background-tertiary mb-8 h-7 w-24 animate-pulse rounded" />
+
+          {/* 프로필 이미지 */}
+          <div className="mb-8 flex justify-center">
+            <div className="bg-background-tertiary h-16 w-16 animate-pulse rounded-[8px] md:h-[100px] md:w-[100px]" />
+          </div>
+
+          {/* 이름 필드 */}
+          <div className="mb-5 space-y-2">
+            <div className="bg-background-tertiary h-4 w-10 animate-pulse rounded" />
+            <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+          </div>
+
+          {/* 이메일 필드 */}
+          <div className="mb-5 space-y-2">
+            <div className="bg-background-tertiary h-4 w-12 animate-pulse rounded" />
+            <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+          </div>
+
+          {/* 비밀번호 필드 */}
+          <div className="mb-8 space-y-2">
+            <div className="bg-background-tertiary h-4 w-14 animate-pulse rounded" />
+            <div className="bg-background-tertiary h-12 w-full animate-pulse rounded-lg" />
+          </div>
+
+          {/* 회원 탈퇴 */}
+          <div className="bg-background-tertiary h-5 w-24 animate-pulse rounded" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function MySettings() {
   return (
-    <FetchBoundary
-      loadingFallback={
-        <div className="bg-background-secondary flex min-h-screen items-center justify-center">
-          <span className="text-color-default text-md-r">로딩 중...</span>
-        </div>
-      }
-    >
+    <FetchBoundary loadingFallback={<MySettingsSkeleton />}>
       <MySettingsContent />
     </FetchBoundary>
   );

--- a/src/pages/team.tsx
+++ b/src/pages/team.tsx
@@ -1,8 +1,12 @@
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { FetchBoundary } from "@/providers/boundary";
 import TaskColumn from "@/features/taskcolumn/TaskColumn";
+import TaskColumnSkeleton from "@/features/taskcolumn/TaskColumnSkeleton";
 import TeamMemberSection from "@/features/TeamMemberSectiom/TeamMemberSection";
+import TeamMemberSkeleton from "@/features/TeamMemberSectiom/TeamMemberSkeleton";
 import TodayProgressSection from "@/features/TodayProgressSection/TodayProgressSection";
+import TodayProgressSkeleton from "@/features/TodayProgressSection/TodayProgressSkeleton";
 import NothingTeamImage from "@/assets/nothingTeam.svg";
 import { Button } from "@/components/common/Button/Button";
 
@@ -68,7 +72,9 @@ export default function Team() {
           className={`grid transition-all duration-300 ${foldClass.progressGrid}`}
         >
           <div className="overflow-hidden">
-            <TodayProgressSection groupId={groupId} />
+            <FetchBoundary loadingFallback={<TodayProgressSkeleton />}>
+              <TodayProgressSection groupId={groupId} />
+            </FetchBoundary>
           </div>
         </div>
 
@@ -79,17 +85,21 @@ export default function Team() {
           <div
             className={`bg-background-secondary relative flex-1 ${foldClass.divider}`}
           >
-            <TaskColumn
-              groupId={groupId}
-              isCollapsed={isCollapsed}
-              onToggleCollapse={() => setIsCollapsed((prev) => !prev)}
-            />
+            <FetchBoundary loadingFallback={<TaskColumnSkeleton />}>
+              <TaskColumn
+                groupId={groupId}
+                isCollapsed={isCollapsed}
+                onToggleCollapse={() => setIsCollapsed((prev) => !prev)}
+              />
+            </FetchBoundary>
           </div>
 
           {/* 할 일 목록 펼쳐지면 안나오기 */}
           {!isCollapsed && (
             <div className="mt-[70px] hidden md:block">
-              <TeamMemberSection groupId={groupId} />
+              <FetchBoundary loadingFallback={<TeamMemberSkeleton />}>
+                <TeamMemberSection groupId={groupId} />
+              </FetchBoundary>
             </div>
           )}
         </div>

--- a/src/providers/boundary/DefaultLoadingFallback.tsx
+++ b/src/providers/boundary/DefaultLoadingFallback.tsx
@@ -1,6 +1,7 @@
 export function DefaultLoadingFallback() {
   return (
-    <div className="text-color-secondary flex items-center justify-center p-8 text-sm">
+    <div className="text-color-secondary flex items-center justify-center gap-2 p-8 text-sm">
+      <div className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent" />
       로딩 중...
     </div>
   );


### PR DESCRIPTION
- team.tsx: TodayProgressSection, TaskColumn, TeamMemberSection 섹션별 FetchBoundary 적용
- EditTeam, AddTeam, JoinTeam: FetchBoundary + Content 분리 + Skeleton + isPending 처리
- GNB: GnbUserProfile, DesktopTeamSelector, MobileHeaderMenus FetchBoundary 적용
- MySettings: 로딩 텍스트를 MySettingsSkeleton으로 교체
- DefaultLoadingFallback: Spinner 아이콘 추가

## #️⃣연관된 이슈

> #79 

## 📝작업 내용
## Summary

useSuspenseQuery를 사용하는 컴포넌트들에 FetchBoundary(ErrorBoundary + Suspense)가 누락되어,
하나의 API 실패 시 전체 페이지가 crash되는 문제를 해결합니다.
추가로 로딩 시 Skeleton UI를 적용하여 사용자 경험을 개선합니다.

## 변경 내역

### 🔴 긴급 — FetchBoundary 누락 수정

#### team.tsx — 섹션별 FetchBoundary 추가
- [x] `<TodayProgressSection>` FetchBoundary 감싸기 + `TodayProgressSkeleton` 생성
- [x] `<TaskColumn>` FetchBoundary 감싸기 + `TaskColumnSkeleton` 생성
- [x] `<TeamMemberSection>` FetchBoundary 감싸기 + `TeamMemberSkeleton` 생성
- 이유: 3개 섹션 모두 내부에서 useSuspenseQuery 사용하지만 보호 없음. 하나 실패하면 전체 페이지 crash

#### EditTeam.tsx — 페이지 레벨 FetchBoundary 추가
- [x] FetchBoundary 감싸기 (useGroup + useGroups 모두 useSuspenseQuery)
- [x] EditTeamSkeleton 생성 (카드 폼 레이아웃)
- [x] 데이터 로직을 별도 `EditTeamContent` 컴포넌트로 분리
- [x] 수정하기 버튼에 `disabled={isPending}` + "수정 중..." 텍스트 추가

#### AddTeam.tsx — 페이지 레벨 FetchBoundary 추가
- [x] FetchBoundary 감싸기 (useGroups가 useSuspenseQuery)
- [x] AddTeamSkeleton 생성 (카드 폼 레이아웃)
- [x] 데이터 로직을 별도 `AddTeamContent` 컴포넌트로 분리
- [x] 생성하기 버튼에 `disabled={isPending}` + "생성 중..." 텍스트 추가

#### JoinTeam.tsx — 페이지 레벨 FetchBoundary 추가
- [x] FetchBoundary 감싸기 (useUser가 useSuspenseQuery)
- [x] JoinTeamSkeleton 생성 (카드 폼 레이아웃)
- [x] 데이터 로직을 별도 `JoinTeamContent` 컴포넌트로 분리
- [x] 참여하기 버튼에 `disabled={isPending}` + "참여 중..." 텍스트 추가

#### GNB 컴포넌트 — FetchBoundary 추가
- [x] `GnbUserProfile` — useUser() 사용 → DesktopGnb에서 FetchBoundary 감싸기 (아바타 스켈레톤)
- [x] `DesktopTeamSelector` — useGroups() 사용 → DesktopHeaderMenus에서 FetchBoundary 감싸기 (리스트 스켈레톤)
- [x] `MobileHeaderMenus` — useGroups() 사용 → MobileGnb에서 FetchBoundary 감싸기 (fallback: null)

### 🟡 개선 — Skeleton / 로딩 UX 향상

#### MySettings.tsx — Skeleton 교체
- [x] 기존 "로딩 중..." 텍스트 → `MySettingsSkeleton` 컴포넌트로 교체 (카드+프로필+입력 필드 레이아웃)

#### DefaultLoadingFallback.tsx — Spinner 아이콘 추가
- [x] "로딩 중..." 텍스트에 CSS animate-spin Spinner 아이콘 추가

## 신규 파일

| 파일 | 설명 |
|------|------|
| `features/TodayProgressSection/TodayProgressSkeleton.tsx` | 그룹 헤더 + 진행도 + 프로그레스 바 스켈레톤 |
| `features/taskcolumn/TaskColumnSkeleton.tsx` | 할 일 목록 헤더 + 3컬럼(할 일/진행중/완료) 스켈레톤 |
| `features/TeamMemberSectiom/TeamMemberSkeleton.tsx` | 멤버 카드(240px) + 멤버 리스트 스켈레톤 |

## 수정 파일 (9개)

| 파일 | 주요 변경 |
|------|-----------|
| `pages/team.tsx` | 3개 섹션에 FetchBoundary + Skeleton fallback 적용 |
| `pages/EditTeam.tsx` | EditTeamContent 분리 + FetchBoundary + Skeleton + isPending |
| `pages/AddTeam.tsx` | AddTeamContent 분리 + FetchBoundary + Skeleton + isPending |
| `pages/JoinTeam.tsx` | JoinTeamContent 분리 + FetchBoundary + Skeleton + isPending |
| `components/gnb/desktop/DesktopGnb.tsx` | GnbUserProfile에 FetchBoundary 적용 |
| `components/gnb/desktop/DesktopHeaderMenus.tsx` | DesktopTeamSelector에 FetchBoundary 적용 |
| `components/gnb/mobile/MobileGnb.tsx` | MobileHeaderMenus에 FetchBoundary 적용 |
| `pages/MySettings.tsx` | 로딩 fallback을 MySettingsSkeleton으로 교체 |
| `providers/boundary/DefaultLoadingFallback.tsx` | Spinner 아이콘 추가 |
