### PR TITLE
HOC 컴포넌트로 로그인/비로그인 네비게이트 처리

### DIFF
--- a/src/app/router.tsx
+++ b/src/app/router.tsx
@@ -18,6 +18,23 @@ import AddTeam from "@/pages/AddTeam";
 import EditTeam from "@/pages/EditTeam";
 import MySettings from "@/pages/MySettings";
 import ListPage from "@/pages/ListPage/ListPage";
+import withAuth from "@/hoc/withAuth";
+import withLoggedInRedirect from "@/hoc/withLoggedInRedirect";
+
+// 보호 페이지: 로그인 필요
+const ProtectedTeam = withAuth(Team);
+const ProtectedEditTeam = withAuth(EditTeam);
+const ProtectedMyHistory = withAuth(MyHistory);
+const ProtectedJoinTeam = withAuth(JoinTeam);
+const ProtectedAddTeam = withAuth(AddTeam);
+const ProtectedBoards = withAuth(Boards);
+const ProtectedBoardWrite = withAuth(BoardWrite);
+const ProtectedBoardDetail = withAuth(BoardDetail);
+const ProtectedMySettings = withAuth(MySettings);
+const ProtectedListPage = withAuth(ListPage);
+
+// 로그인 상태면 /team으로 리다이렉트
+const GuestLoginPage = withLoggedInRedirect(LoginPage);
 
 export const router = createBrowserRouter([
   {
@@ -35,7 +52,7 @@ export const router = createBrowserRouter([
           {
             path: "login",
             children: [
-              { index: true, element: <LoginPage /> },
+              { index: true, element: <GuestLoginPage /> },
               { path: "kakao", element: <KakaoRedirectPage /> },
             ],
           },
@@ -43,24 +60,24 @@ export const router = createBrowserRouter([
           {
             path: "team",
             children: [
-              { index: true, element: <Team /> },
-              { path: ":id", element: <Team /> },
-              { path: ":id/edit", element: <EditTeam /> },
-              { path: ":id/my-history", element: <MyHistory /> },
-              { path: "join", element: <JoinTeam /> },
-              { path: "add", element: <AddTeam /> },
+              { index: true, element: <ProtectedTeam /> },
+              { path: ":id", element: <ProtectedTeam /> },
+              { path: ":id/edit", element: <ProtectedEditTeam /> },
+              { path: ":id/my-history", element: <ProtectedMyHistory /> },
+              { path: "join", element: <ProtectedJoinTeam /> },
+              { path: "add", element: <ProtectedAddTeam /> },
             ],
           },
           {
             path: "boards",
             children: [
-              { index: true, element: <Boards /> },
-              { path: "write", element: <BoardWrite /> },
-              { path: ":articleId", element: <BoardDetail /> },
+              { index: true, element: <ProtectedBoards /> },
+              { path: "write", element: <ProtectedBoardWrite /> },
+              { path: ":articleId", element: <ProtectedBoardDetail /> },
             ],
           },
-          { path: "my-settings", element: <MySettings /> },
-          { path: "list", element: <ListPage /> },
+          { path: "my-settings", element: <ProtectedMySettings /> },
+          { path: "list", element: <ProtectedListPage /> },
         ],
       },
       {

--- a/src/hoc/withAuth.tsx
+++ b/src/hoc/withAuth.tsx
@@ -1,0 +1,22 @@
+import { type ComponentType, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/stores/useAuthStore";
+
+export default function withAuth<Props extends object>(
+  Component: ComponentType<Props>,
+) {
+  return function AuthenticatedComponent(props: Props) {
+    const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+      if (!isLoggedIn) {
+        navigate("/login", { replace: true });
+      }
+    }, [isLoggedIn, navigate]);
+
+    if (!isLoggedIn) return null;
+
+    return <Component {...props} />;
+  };
+}

--- a/src/hoc/withLoggedInRedirect.tsx
+++ b/src/hoc/withLoggedInRedirect.tsx
@@ -1,0 +1,22 @@
+import { type ComponentType, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuthStore } from "@/stores/useAuthStore";
+
+export default function withLoggedInRedirect<Props extends object>(
+  Component: ComponentType<Props>,
+) {
+  return function LoggedInRedirectComponent(props: Props) {
+    const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+      if (isLoggedIn) {
+        navigate("/team", { replace: true });
+      }
+    }, [isLoggedIn, navigate]);
+
+    if (isLoggedIn) return null;
+
+    return <Component {...props} />;
+  };
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #83 

## 📝작업 내용

- HOC 기반 로그인 가드(withAuth) 컴포넌트 구현
- 로그인하지 않은 사용자의 보호 페이지 접근 차단 및 로그인 페이지 리다이렉트 처리

## 참고문서

[withAuth HOC ‐ 로그인 보호 시스템 가이드](https://github.com/codeit-Coworkers/coworkers/wiki/withAuth-HOC-%E2%80%90-%EB%A1%9C%EA%B7%B8%EC%9D%B8-%EB%B3%B4%ED%98%B8-%EC%8B%9C%EC%8A%A4%ED%85%9C-%EA%B0%80%EC%9D%B4%EB%93%9C)
