### PR TITLE
자유게시판 UI 개선 (border, 베스트 섹션 가로스크롤, 에러코드 숨김)

### DIFF
--- a/src/features/boards/components/BestPostCarousel/BestPostCarousel.tsx
+++ b/src/features/boards/components/BestPostCarousel/BestPostCarousel.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { useIsMobile } from "@/hooks/useMediaQuery";
 import PostCard from "../PostCard";
@@ -19,18 +19,15 @@ interface BestPost {
 interface BestPostCarouselProps {
   /** 베스트 게시글 목록 */
   posts: BestPost[];
-  /** 더보기 클릭 핸들러 */
-  onMoreClick?: () => void;
 }
 
-// Breakpoint별 설정
-type Breakpoint = "mobile" | "tablet" | "desktop";
+// Breakpoint별 설정 (태블릿/데스크톱용)
+type Breakpoint = "tablet" | "desktop";
 
 const CAROUSEL_CONFIG: Record<
   Breakpoint,
   { cardsPerPage: number; cardSize: "small" | "large"; titleClass: string }
 > = {
-  mobile: { cardsPerPage: 1, cardSize: "small", titleClass: "text-2lg-b" },
   tablet: { cardsPerPage: 2, cardSize: "small", titleClass: "text-xl-b" },
   desktop: { cardsPerPage: 3, cardSize: "large", titleClass: "text-xl-b" },
 };
@@ -39,95 +36,149 @@ const CAROUSEL_CONFIG: Record<
  * 베스트 게시글 캐러셀 컴포넌트
  *
  * @description
- * 데스크톱: 3개 카드 (large)
- * 태블릿: 2개 카드 (small)
- * 모바일: 1개 카드 (small)
- *
- * breakpoint 변경 시 key가 바뀌어 컴포넌트가 리마운트되며,
- * 이를 통해 currentPage가 자동으로 0으로 초기화됩니다.
+ * 데스크톱: 3개 카드 (large) — 페이지네이션 캐러셀
+ * 태블릿: 2개 카드 (small) — 페이지네이션 캐러셀
+ * 모바일: 가로 스크롤 + snap (좁으면 1개, 넓으면 2개) + 점 표시
  */
-export default function BestPostCarousel({
-  posts,
-  onMoreClick,
-}: BestPostCarouselProps) {
+export default function BestPostCarousel({ posts }: BestPostCarouselProps) {
   const isMobile = useIsMobile(); // < 768px
   const isTablet = useIsMobile("lg"); // < 1024px
 
-  // breakpoint 식별 - 변경 시 컴포넌트 리마운트
-  const breakpoint: Breakpoint = isMobile
-    ? "mobile"
-    : isTablet
-      ? "tablet"
-      : "desktop";
+  if (isMobile) {
+    return <MobileBestPostScroll posts={posts} />;
+  }
+
+  const breakpoint: Breakpoint = isTablet ? "tablet" : "desktop";
 
   return (
-    <BestPostCarouselInner
+    <DesktopBestPostCarousel
       key={breakpoint}
       posts={posts}
-      onMoreClick={onMoreClick}
       breakpoint={breakpoint}
     />
   );
 }
 
-/** 실제 캐러셀 로직을 담은 내부 컴포넌트 */
-function BestPostCarouselInner({
-  posts,
-  onMoreClick,
-  breakpoint,
-}: BestPostCarouselProps & { breakpoint: Breakpoint }) {
-  const { cardsPerPage, cardSize, titleClass } = CAROUSEL_CONFIG[breakpoint];
+// ─── 모바일: 가로 스크롤 + snap + 점 표시 ────────────────────
 
-  // 총 페이지 수
-  const totalPages = Math.ceil(posts.length / cardsPerPage);
-  const maxPage = Math.max(0, totalPages - 1);
+/** 480px 이상이면 2개, 미만이면 1개 */
+function useCardsPerView() {
+  const [cardsPerView, setCardsPerView] = useState(() =>
+    typeof window !== "undefined" && window.innerWidth >= 480 ? 2 : 1,
+  );
 
-  // 현재 페이지 상태 (breakpoint 변경 시 리마운트되어 0으로 초기화됨)
+  useEffect(() => {
+    const check = () => setCardsPerView(window.innerWidth >= 480 ? 2 : 1);
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+
+  return cardsPerView;
+}
+
+function MobileBestPostScroll({ posts }: { posts: BestPost[] }) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const cardsPerView = useCardsPerView();
+  const totalPages = Math.ceil(posts.length / cardsPerView);
   const [currentPage, setCurrentPage] = useState(0);
 
-  // 현재 페이지에 표시할 카드들
-  const startIndex = currentPage * cardsPerPage;
-  const visiblePosts = posts.slice(startIndex, startIndex + cardsPerPage);
+  // 스크롤 위치로 현재 페이지 계산
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el || el.clientWidth === 0) return;
+    const page = Math.round(el.scrollLeft / el.clientWidth);
+    setCurrentPage(Math.min(page, totalPages - 1));
+  }, [totalPages]);
 
-  // 페이지 이동
-  const handlePrev = () => {
-    setCurrentPage((prev) => Math.max(0, prev - 1));
-  };
+  // 점 클릭 시 해당 페이지로 스크롤
+  const scrollToPage = useCallback((page: number) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollTo({ left: page * el.clientWidth, behavior: "smooth" });
+  }, []);
 
-  const handleNext = () => {
-    setCurrentPage((prev) => Math.min(maxPage, prev + 1));
-  };
+  // 카드 너비: 2개일 때 50%-gap/2, 1개일 때 100%
+  const cardWidth = cardsPerView === 2 ? "calc((100% - 12px) / 2)" : "100%";
 
   return (
     <section className="bg-background-secondary rounded-xl p-6">
       {/* 헤더 */}
-      <div className="mb-6 flex items-center justify-between">
-        <h2 className={`${titleClass} text-color-primary`}>베스트 게시글</h2>
-        <button
-          type="button"
-          onClick={onMoreClick}
-          className="text-md-r flex items-center gap-1 text-[#94A3B8] transition-colors hover:text-[#64748B]"
-        >
-          더보기
-          <svg
-            width="16"
-            height="16"
-            viewBox="0 0 16 16"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
+      <h2 className="text-2lg-b text-color-primary mb-6">베스트 게시글</h2>
+
+      {/* 가로 스크롤 영역 */}
+      <style>{`[data-best-scroll]::-webkit-scrollbar { display: none; }`}</style>
+      <div
+        ref={scrollRef}
+        onScroll={handleScroll}
+        data-best-scroll=""
+        className="flex snap-x snap-mandatory gap-3 overflow-x-auto"
+        style={{ scrollbarWidth: "none" }}
+      >
+        {posts.map((post) => (
+          <Link
+            key={post.id}
+            to={`/boards/${post.id}`}
+            className="flex-shrink-0 snap-start"
+            style={{ width: cardWidth }}
           >
-            <path
-              d="M6 4L10 8L6 12"
-              stroke="#475569"
-              strokeWidth="1.54"
-              strokeLinecap="round"
-              strokeLinejoin="round"
+            <PostCard
+              state="best"
+              size="small"
+              title={post.title}
+              content={post.content}
+              author={post.author}
+              date={post.date}
+              likeCount={post.likeCount}
+              imageUrl={post.imageUrl}
+              fullWidth
             />
-          </svg>
-        </button>
+          </Link>
+        ))}
       </div>
 
-      {/* 카드 영역 - 클릭 시 해당 게시글 상세로 이동 (데스크 3장/태블릿 2장 세트 가운데 정렬) */}
+      {/* 캐러셀 점 */}
+      {totalPages > 1 && (
+        <div className="mt-6 flex justify-center">
+          <CarouselDots
+            total={totalPages}
+            current={currentPage}
+            onPageChange={scrollToPage}
+          />
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ─── 태블릿/데스크톱: 페이지네이션 캐러셀 ───────────────────
+
+function DesktopBestPostCarousel({
+  posts,
+  breakpoint,
+}: {
+  posts: BestPost[];
+  breakpoint: Breakpoint;
+}) {
+  const { cardsPerPage, cardSize, titleClass } = CAROUSEL_CONFIG[breakpoint];
+
+  const totalPages = Math.ceil(posts.length / cardsPerPage);
+  const maxPage = Math.max(0, totalPages - 1);
+
+  const [currentPage, setCurrentPage] = useState(0);
+
+  const startIndex = currentPage * cardsPerPage;
+  const visiblePosts = posts.slice(startIndex, startIndex + cardsPerPage);
+
+  const handlePrev = () => setCurrentPage((prev) => Math.max(0, prev - 1));
+  const handleNext = () =>
+    setCurrentPage((prev) => Math.min(maxPage, prev + 1));
+
+  return (
+    <section className="bg-background-secondary rounded-xl p-6">
+      {/* 헤더 */}
+      <h2 className={`${titleClass} text-color-primary mb-6`}>베스트 게시글</h2>
+
+      {/* 카드 영역 */}
       <div className="flex justify-center gap-3">
         {visiblePosts.map((post) => (
           <Link key={post.id} to={`/boards/${post.id}`} className="flex-none">
@@ -145,17 +196,14 @@ function BestPostCarouselInner({
         ))}
       </div>
 
-      {/* 컨트롤 영역 (점: 가운데, 화살표: 오른쪽 끝) */}
+      {/* 컨트롤 영역 */}
       {totalPages > 1 && (
         <div className="relative mt-6 flex items-center justify-center">
-          {/* 점 (가운데) */}
           <CarouselDots
             total={totalPages}
             current={currentPage}
             onPageChange={setCurrentPage}
           />
-
-          {/* 화살표 (오른쪽 끝) */}
           <div className="absolute right-0">
             <CarouselArrows
               onPrev={handlePrev}

--- a/src/features/boards/components/BestPostSection/BestPostSection.tsx
+++ b/src/features/boards/components/BestPostSection/BestPostSection.tsx
@@ -7,7 +7,7 @@ function toBestPost(article: ArticleSummary) {
   return {
     id: article.id,
     title: article.title,
-    content: "",
+    content: article.content ?? "",
     author: article.writer.nickname,
     date: formatDate(article.createdAt),
     likeCount: article.likeCount,

--- a/src/features/boards/components/BoardListGrid/BoardListGrid.tsx
+++ b/src/features/boards/components/BoardListGrid/BoardListGrid.tsx
@@ -27,7 +27,7 @@ export default function BoardListGrid({
             state="default"
             size={cardSize}
             title={article.title}
-            content=""
+            content={article.content ?? ""}
             author={article.writer.nickname}
             date={formatDate(article.createdAt)}
             likeCount={article.likeCount}

--- a/src/features/boards/components/PostCard/PostCard.tsx
+++ b/src/features/boards/components/PostCard/PostCard.tsx
@@ -190,7 +190,7 @@ export default function PostCard({
   // Default 카드 레이아웃
   return (
     <article
-      className={`bg-background-inverse flex flex-col rounded-[20px] ${widthClass} ${contentAuthorGap}`}
+      className={`bg-background-inverse border-border-primary flex flex-col rounded-[20px] border ${widthClass} ${contentAuthorGap}`}
     >
       {/* 제목 + 본문 + 이미지 */}
       <div className="flex flex-1 items-start gap-2">

--- a/src/lib/queryClient.ts
+++ b/src/lib/queryClient.ts
@@ -16,9 +16,7 @@ export const queryClient = new QueryClient({
       onError: (error) => {
         const errorData = getErrorDataByCode(error);
         // zustand store의 getState()로 React 외부에서 접근
-        useToastStore
-          .getState()
-          .show(`[${errorData.code}] ${errorData.message}`);
+        useToastStore.getState().show(errorData.message);
       },
     },
   },

--- a/src/pages/Boards.tsx
+++ b/src/pages/Boards.tsx
@@ -22,7 +22,7 @@ const SORT_MAP: Record<SortLabel, "recent" | "like"> = {
 // ─── 베스트 게시글 섹션 (Suspense 내부) ─────────────────────
 
 function BestPostSection() {
-  const { data } = useBestArticles(5);
+  const { data } = useBestArticles(15);
 
   // API 응답 → BestPostCarousel 형식으로 변환
   const bestPosts = data.list.map(toBestPost);
@@ -246,7 +246,7 @@ export default function Boards() {
                     state="default"
                     size={cardSize}
                     title={article.title}
-                    content=""
+                    content={article.content ?? ""}
                     author={article.writer.nickname}
                     date={formatDate(article.createdAt)}
                     likeCount={article.likeCount}
@@ -326,7 +326,7 @@ function toBestPost(article: ArticleSummary) {
   return {
     id: article.id,
     title: article.title,
-    content: "", // 목록 API는 content를 반환하지 않음
+    content: article.content ?? "",
     author: article.writer.nickname,
     date: formatDate(article.createdAt),
     likeCount: article.likeCount,

--- a/src/types/article.ts
+++ b/src/types/article.ts
@@ -16,6 +16,7 @@ export interface ArticleSummary {
   likeCount: number;
   writer: ArticleWriter;
   image: string | null;
+  content?: string;
   title: string;
   id: number;
 }


### PR DESCRIPTION
- PostCard: 일반 게시글 카드에 border-border-primary 추가
- BestPostCarousel: 모바일 가로 스크롤 + snap 방식으로 변경 (좁으면 1개, 넓으면 2개)
- BestPostCarousel: 더보기 버튼 제거, 베스트 게시글 최대 15개로 확대
- queryClient: 토스트 에러 메시지에서 에러코드([403] 등) 제거
- ArticleSummary: content 필드 optional 추가 (백엔드 대응 시 자동 표시)

## #️⃣연관된 이슈

> #85 

## 📝작업 내용

각 항목에 개별 border 적용
description 영역은 말줄임(…) 처리 -> api가 제목만 반환해서 어려울듯
흰 카드 영역이 꽉 차도록 레이아웃 수정 or 카드 개수는 구간별로 2개씩 표시되도록 조정
“더보기” 버튼 제거
모바일에서 슬라이드(가로 스크롤) 가능하도록 구현
UI 상에서 에러코드 노출되지 않도록 처리