### PR TITLE
fix: 자유게시판 및 계정설정 페이지 UI/UX 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1492,6 +1493,7 @@
       "version": "9.5.0",
       "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.5.0.tgz",
       "integrity": "sha512-FiUzfYW4wB1+PpmsE47UM+mCads7j2+giRBltfwH7SNhah95rqJs3ltEs9V3pP8rYdS0QlNne+9Aj8dS/SiaIA==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.17.8",
         "@types/webxr": "*",
@@ -2509,6 +2511,7 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -2523,6 +2526,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2554,6 +2558,7 @@
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
       "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
+      "peer": true,
       "dependencies": {
         "@dimforge/rapier3d-compat": "~0.12.0",
         "@tweenjs/tween.js": "~23.1.3",
@@ -2614,6 +2619,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -2886,6 +2892,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3101,6 +3108,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3440,6 +3448,7 @@
       "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "env-paths": "^2.2.1",
         "import-fresh": "^3.3.0",
@@ -3743,6 +3752,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5512,6 +5522,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5551,6 +5562,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5594,6 +5606,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5707,6 +5720,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5716,6 +5730,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6186,7 +6201,8 @@
     "node_modules/three": {
       "version": "0.182.0",
       "resolved": "https://registry.npmjs.org/three/-/three-0.182.0.tgz",
-      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ=="
+      "integrity": "sha512-GbHabT+Irv+ihI1/f5kIIsZ+Ef9Sl5A1Y7imvS5RQjWgtTPfPnZ43JmlYI7NtCRDK9zir20lQpfg8/9Yd02OvQ==",
+      "peer": true
     },
     "node_modules/three-mesh-bvh": {
       "version": "0.8.3",
@@ -6363,6 +6379,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6477,6 +6494,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -6695,6 +6713,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/features/Boards/components/BestPostCarousel/BestPostCarousel.tsx
+++ b/src/features/Boards/components/BestPostCarousel/BestPostCarousel.tsx
@@ -177,14 +177,18 @@ function DesktopBestPostCarousel({
     setCurrentPage((prev) => Math.min(maxPage, prev + 1));
 
   return (
-    <section className="bg-background-secondary rounded-xl p-6">
+    <section className="bg-background-secondary min-w-0 overflow-hidden rounded-xl p-6">
       {/* 헤더 */}
       <h2 className={`${titleClass} text-color-primary mb-6`}>베스트 게시글</h2>
 
       {/* 카드 영역 */}
-      <div className="flex justify-center gap-3">
+      <div className="flex gap-3">
         {visiblePosts.map((post) => (
-          <Link key={post.id} to={`/boards/${post.id}`} className="flex-none">
+          <Link
+            key={post.id}
+            to={`/boards/${post.id}`}
+            className="min-w-0 flex-1"
+          >
             <PostCard
               state="best"
               size={cardSize}
@@ -194,6 +198,7 @@ function DesktopBestPostCarousel({
               date={post.date}
               likeCount={post.likeCount}
               imageUrl={post.imageUrl}
+              fullWidth
             />
           </Link>
         ))}

--- a/src/features/Boards/components/BoardListHeader/BoardListHeader.tsx
+++ b/src/features/Boards/components/BoardListHeader/BoardListHeader.tsx
@@ -24,8 +24,10 @@ export default function BoardListHeader({
         isMobile ? "flex flex-col gap-5" : "flex items-center justify-between"
       }`}
     >
-      <h1 className={`${titleClass} text-color-primary`}>자유게시판</h1>
-      <div className={isMobile ? "w-full" : "w-[420px]"}>
+      <h1 className={`${titleClass} text-color-primary shrink-0 whitespace-nowrap`}>
+        자유게시판
+      </h1>
+      <div className={isMobile ? "w-full" : "min-w-0 flex-1 max-w-[420px]"}>
         <Input
           variant="search"
           withSearchIcon

--- a/src/features/Boards/components/BoardListSection/BoardListSection.tsx
+++ b/src/features/Boards/components/BoardListSection/BoardListSection.tsx
@@ -61,7 +61,7 @@ export default function BoardListSection({
           articles={displayArticles}
           gridClass={gridClass}
           cardSize={cardSize}
-          fullWidth={isMobile || isTablet}
+          fullWidth
         />
       ) : (
         <BoardListEmpty keyword={debouncedKeyword || undefined} />

--- a/src/features/Boards/components/FloatingWriteButton/FloatingWriteButton.tsx
+++ b/src/features/Boards/components/FloatingWriteButton/FloatingWriteButton.tsx
@@ -8,7 +8,7 @@ export default function FloatingWriteButton() {
   return (
     <Link
       to="/boards/write"
-      className="bg-brand-primary hover:bg-interaction-hover fixed right-[120px] bottom-[76px] flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-colors"
+      className="bg-brand-primary fixed right-[120px] bottom-[76px] flex h-14 w-14 items-center justify-center rounded-full shadow-lg transition-transform hover:scale-105 active:scale-95"
     >
       <PlusIcon className="h-6 w-6 text-white" />
     </Link>

--- a/src/features/Boards/components/PostCard/PostCard.tsx
+++ b/src/features/Boards/components/PostCard/PostCard.tsx
@@ -131,7 +131,7 @@ export default function PostCard({
   if (state === "best") {
     return (
       <article
-        className={`bg-background-inverse flex flex-col ${chipGap} rounded-[20px] ${widthClass}`}
+        className={`bg-background-inverse flex flex-col ${chipGap} rounded-[20px] cursor-pointer ${widthClass}`}
       >
         {/* 인기 칩 */}
         <div className="bg-background-secondary flex h-[30px] w-[72px] items-center justify-center gap-1 rounded-xl">
@@ -190,7 +190,7 @@ export default function PostCard({
   // Default 카드 레이아웃
   return (
     <article
-      className={`bg-background-inverse border-border-primary flex flex-col rounded-[20px] border ${widthClass} ${contentAuthorGap}`}
+      className={`bg-background-inverse border-border-primary flex flex-col rounded-[20px] border transition-colors hover:bg-background-secondary ${widthClass} ${contentAuthorGap}`}
     >
       {/* 제목 + 본문 + 이미지 */}
       <div className="flex flex-1 items-start gap-2">

--- a/src/features/MySettings/components/PasswordChangeModal.tsx
+++ b/src/features/MySettings/components/PasswordChangeModal.tsx
@@ -3,6 +3,7 @@ import Modal from "@/components/common/Modal/Modal";
 import { Input } from "@/components/common/Input/Input";
 import { useChangePassword } from "@/api/user";
 import { useIsMobile } from "@/hooks/useMediaQuery";
+import { useToastStore } from "@/stores/useToastStore";
 
 interface PasswordChangeModalProps {
   isOpen: boolean;
@@ -29,6 +30,7 @@ export default function PasswordChangeModal({
   const [confirmError, setConfirmError] = useState("");
 
   const changePassword = useChangePassword();
+  const showToast = useToastStore((s) => s.show);
 
   const isValid =
     password.length > 0 &&
@@ -75,6 +77,7 @@ export default function PasswordChangeModal({
         onSuccess: () => {
           setPassword("");
           setPasswordConfirmation("");
+          showToast("비밀번호가 변경되었습니다.");
           onSuccess?.();
           onClose();
         },
@@ -130,7 +133,7 @@ export default function PasswordChangeModal({
           <button
             type="button"
             onClick={onClose}
-            className="text-color-primary border-border-primary text-md-sb h-12 flex-1 rounded-lg border-2 bg-white text-center"
+            className="text-color-primary border-border-primary text-md-sb h-12 flex-1 rounded-lg border-2 bg-white text-center transition-colors hover:bg-background-secondary"
           >
             닫기
           </button>
@@ -138,7 +141,7 @@ export default function PasswordChangeModal({
             type="button"
             onClick={handleSubmit}
             disabled={!isValid || changePassword.isPending}
-            className="bg-brand-primary text-color-inverse text-md-sb hover:bg-interaction-hover h-12 flex-1 rounded-lg text-center transition-colors disabled:cursor-not-allowed disabled:opacity-50"
+            className="bg-brand-primary text-color-inverse text-md-sb h-12 flex-1 rounded-lg text-center transition-colors hover:bg-interaction-hover disabled:cursor-not-allowed disabled:opacity-50"
           >
             {changePassword.isPending ? "변경 중..." : "변경하기"}
           </button>

--- a/src/features/MySettings/components/WithdrawModal.tsx
+++ b/src/features/MySettings/components/WithdrawModal.tsx
@@ -45,7 +45,7 @@ export default function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
           <button
             type="button"
             onClick={onClose}
-            className="text-color-default border-border-primary text-md-sb h-12 w-[135px] rounded-lg border bg-white text-center"
+            className="text-color-default border-border-primary text-md-sb h-12 w-[135px] rounded-lg border bg-white text-center transition-colors hover:bg-background-secondary"
           >
             닫기
           </button>
@@ -53,7 +53,7 @@ export default function WithdrawModal({ isOpen, onClose }: WithdrawModalProps) {
             type="button"
             onClick={handleWithdraw}
             disabled={deleteUser.isPending}
-            className="bg-status-danger text-color-inverse text-md-sb h-12 w-[135px] rounded-lg text-center disabled:opacity-50"
+            className="bg-status-danger text-color-inverse text-md-sb h-12 w-[135px] rounded-lg text-center transition-colors hover:opacity-80 disabled:opacity-50"
           >
             {deleteUser.isPending ? "처리 중..." : "회원 탈퇴"}
           </button>

--- a/src/pages/MySettings.tsx
+++ b/src/pages/MySettings.tsx
@@ -10,6 +10,7 @@ import WithdrawModal from "@/features/MySettings/components/WithdrawModal";
 import AlertIcon from "@/assets/alert-white.svg";
 import PencilIcon from "@/assets/pencil.svg";
 import SecessionIcon from "@/assets/secession.svg";
+import UserDefaultProfile from "@/assets/user.svg";
 
 /**
  * 계정 설정 페이지
@@ -153,11 +154,17 @@ function MySettingsContent() {
                 className="relative inline-block disabled:opacity-70"
                 aria-label="프로필 이미지 변경"
               >
-                <img
-                  src={profileImageUrl}
-                  alt="프로필"
-                  className={`${profileSize} ${profileRadius} object-cover ${uploadImageMutation.isPending ? "animate-pulse" : ""}`}
-                />
+                {profileImageUrl ? (
+                  <img
+                    src={profileImageUrl}
+                    alt="프로필"
+                    className={`${profileSize} ${profileRadius} object-cover ${uploadImageMutation.isPending ? "animate-pulse" : ""}`}
+                  />
+                ) : (
+                  <UserDefaultProfile
+                    className={`${profileSize} ${profileRadius} ${uploadImageMutation.isPending ? "animate-pulse" : ""}`}
+                  />
+                )}
                 <span
                   className={`bg-background-secondary [&_path]:!fill-icon-primary absolute right-[-9px] bottom-[-9px] flex items-center justify-center rounded-full shadow md:right-[-16px] md:bottom-[-16px] ${isMobile ? "h-[18px] w-[18px]" : "h-8 w-8"}`}
                 >
@@ -230,7 +237,7 @@ function MySettingsContent() {
             {/* 회원 탈퇴하기 */}
             <button
               type="button"
-              className="text-status-danger flex items-center gap-2"
+              className="text-status-danger flex items-center gap-2 transition-opacity hover:opacity-70"
               onClick={() => setWithdrawModalOpen(true)}
             >
               <SecessionIcon className="h-5 w-5" />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #101 

## 📝작업 내용
## Summary

### 자유게시판 (Boards)
- GNB 열림/특정 구간(~1000px)에서 베스트 게시글 카드 및 전체 게시글 카드가 컨테이너 밖으로 넘치는 레이아웃 깨짐 수정
  - 베스트 캐러셀: 고정 너비(`flex-none`) → 유연한 너비(`flex-1 min-w-0 + fullWidth`)로 변경, 섹션에 `overflow-hidden` 추가
  - 전체 게시글 그리드: 항상 `fullWidth`로 렌더링하여 CSS Grid 셀에 맞게 리사이즈
- '자유게시판' 제목이 좁은 화면에서 줄바꿈되는 문제 수정 (`whitespace-nowrap`, 검색창 유연 너비 적용)
- 전체 게시글 카드 hover 시 `bg-background-secondary` 배경색 변경 효과 추가 (캘린더 호버 색상과 통일)
- 플로팅 글쓰기(+) 버튼: 배경색 hover → `hover:scale-105 active:scale-95` 스케일 효과로 변경 (리스트 페이지와 통일)

### 계정설정 (MySettings)
- 프로필 이미지 미설정 시 GNB와 동일한 기본 프로필 이미지(`user.svg`) 표시
- 비밀번호 변경 모달 / 회원 탈퇴 모달 버튼에 hover 효과 추가
- 회원 탈퇴하기 텍스트 버튼 hover 효과 추가
- 비밀번호 변경 성공 시 "비밀번호가 변경되었습니다." 토스트 메시지 표시 (기존 `useToastStore` 활용)

