### PR TITLE
refactor: 모달내에 공통 버튼 컴포넌트로 교체

### DIFF
--- a/src/features/Team/TeamMemberSection/ProfileModal.tsx
+++ b/src/features/Team/TeamMemberSection/ProfileModal.tsx
@@ -1,5 +1,6 @@
 import Close from "@/assets/close.svg";
 import UserDefaultProfile from "@/assets/user.svg";
+import { Button } from "@/components/common/Button/Button";
 import { useToastStore } from "@/stores/useToastStore";
 
 type ProfileModalProps = {
@@ -53,16 +54,16 @@ export default function ProfileModal({
             </div>
           </div>
         </div>
-        <button
+        <Button
           type="button"
-          className="bg-brand-primary text-lg-b text-color-inverse h-[48px] w-[280px] rounded-[12px] text-center"
+          size="authWide"
           onClick={() => {
             emailCopyHandler();
             onClose();
           }}
         >
           이메일 복사하기
-        </button>
+        </Button>
       </div>
     </>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> #108

## 📝작업 내용

> 팀페이지의 오른쪽 멤버초대하기 리스트 클릭시 나오는 모달 (이메일 복사하기) 내에 버튼을 공통 버튼 컴포넌트로 교체

### 스크린샷 (선택)
<img width="531" height="398" alt="스크린샷 2026-02-24 오후 5 56 11" src="https://github.com/user-attachments/assets/b54c5b2f-e041-486b-8e88-c36352397c9b" />

## 💬리뷰 요구사항(선택)
